### PR TITLE
Fix dataview processing

### DIFF
--- a/test/processor.spec.ts
+++ b/test/processor.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { ContentProcessor } from "../src/processor";
 
 test("wikilinks parsing", async () => {
@@ -35,4 +35,58 @@ test("remove wikilink when target is missing", async () => {
       pages: [],
     }),
   ).toEqual("Test Link\n");
+});
+
+test("dataview codeblock", async () => {
+  const processor = new ContentProcessor(
+    {
+      tryQueryMarkdown: vi
+        .fn()
+        .mockImplementation(() => Promise.resolve("Dataview Output")),
+    },
+    {},
+  );
+
+  expect(
+    await processor.processContent(
+      `
+\`\`\`dataview
+LIST
+FROM #web
+\`\`\`
+      `,
+      {
+        page: {},
+        frontmatter: {},
+        pages: [],
+      },
+    ),
+  ).toEqual("Dataview Output\n");
+});
+
+test("dataview codeblock post-processing", async () => {
+  const processor = new ContentProcessor(
+    {
+      tryQueryMarkdown: vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(`- [[Test Link]]`)),
+    },
+    {},
+  );
+
+  expect(
+    await processor.processContent(
+      `
+\`\`\`dataview
+LIST
+FROM #web
+\`\`\`
+      `,
+      {
+        page: {},
+        frontmatter: {},
+        pages: [{ slug: "test-link", file: { name: "Test Link" } }],
+      },
+    ),
+  ).toEqual("* [Test Link](/test-link)\n");
 });


### PR DESCRIPTION
Add tests for this to make sure we don't regress, but the `SKIP`
approach seemed to be causing an infinite loops; presumably, because we
don't actually do the replacement until after the visiting finishes.